### PR TITLE
Support OpenShift web-console

### DIFF
--- a/sno-common.sh
+++ b/sno-common.sh
@@ -12,4 +12,5 @@ rendezvousMAC=52:54:00:93:72:25       # In case of SNO, this is also the host MA
 baseDomain=${network}.org
 domain=sno.${baseDomain}
 apiDomain=api.${domain}
-
+consoleDomain=console-openshift-console.apps.${domain}
+oauthDomain=oauth-openshift.apps.${domain}

--- a/sno-setup.sh
+++ b/sno-setup.sh
@@ -91,7 +91,7 @@ fi
 ###    and this will be required later by the wait-for command
 if ! $(grep "${apiDomain}" /etc/hosts &> /dev/null); then
   echo "* Adding entry to /etc/hosts"
-  echo "${rendezvousIP} ${apiDomain}" | sudo tee -a /etc/hosts
+  echo "${rendezvousIP} ${apiDomain} ${consoleDomain} ${oauthDomain}" | sudo tee -a /etc/hosts
 fi
 
 ### 6. Generate the install-config.yaml and agent-config.yaml.


### PR DESCRIPTION
This PR adds the necessary entries to `/etc/hosts` to allow the user to navigate and connect to the cluster via the OpenShift web console.